### PR TITLE
Add moving average utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # lzwScanner
+
+This repository contains helper utilities for stock scanning.
+
+## Moving Average
+
+`ma.js` exports a `calculateMA` function which computes a simple moving average for an array of price data.
+
+Example usage:
+
+```javascript
+const calculateMA = require('./ma');
+
+const data = [
+  { close: 10 },
+  { close: 11 },
+  { close: 12 },
+  { close: 13 }
+];
+
+const ma = calculateMA(data, 3);
+console.log(ma); // [undefined, undefined, 11, 12]
+```
+
+Data should be sorted by date in ascending order before calling the function.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@ This repository contains helper utilities for stock scanning.
 
 ## Moving Average
 
-`ma.js` exports a `calculateMA` function which computes a simple moving average for an array of price data.
+`ma.js` exports helper functions for working with stock data.
+
+* `calculateMA(data, period, [priceKey])` – compute a simple moving average for any numeric field (defaults to `close`).
+* `calculateAverageVolume(data, period, [volumeKey])` – compute a moving average of volume (defaults to the `volume` field).
 
 Example usage:
 
 ```javascript
-const calculateMA = require('./ma');
+const { calculateMA, calculateAverageVolume } = require('./ma');
 
 const data = [
   { close: 10 },
@@ -20,6 +23,14 @@ const data = [
 
 const ma = calculateMA(data, 3);
 console.log(ma); // [undefined, undefined, 11, 12]
+
+const volMA = calculateAverageVolume([
+  { volume: 100 },
+  { volume: 110 },
+  { volume: 90 },
+  { volume: 120 }
+], 3);
+console.log(volMA); // [undefined, undefined, 100, 106.66666666666667]
 ```
 
 Data should be sorted by date in ascending order before calling the function.

--- a/ma.js
+++ b/ma.js
@@ -37,4 +37,18 @@ function calculateMA(data, period, priceKey = 'close') {
   return result;
 }
 
+/**
+ * Calculate average volume over a period.
+ * This is a thin wrapper over `calculateMA` with `volume` as the default key.
+ * @param {Array<Object>} data - Array of price objects sorted by date ascending.
+ * @param {number} period - Number of periods for the average volume.
+ * @param {string} [volumeKey='volume'] - Key to use for volume in each object.
+ * @returns {Array<number|undefined>} Average volume values for each data point.
+ */
+function calculateAverageVolume(data, period, volumeKey = 'volume') {
+  return calculateMA(data, period, volumeKey);
+}
+
 module.exports = calculateMA;
+module.exports.calculateMA = calculateMA;
+module.exports.calculateAverageVolume = calculateAverageVolume;

--- a/ma.js
+++ b/ma.js
@@ -1,0 +1,40 @@
+/**
+ * Calculate simple moving average for given data.
+ * @param {Array<Object>} data - Array of price objects sorted by date ascending.
+ * @param {number} period - Number of periods for the moving average.
+ * @param {string} [priceKey='close'] - Key to use for the price in each object.
+ * @returns {Array<number|undefined>} Moving average values for each data point.
+ */
+function calculateMA(data, period, priceKey = 'close') {
+  if (!Array.isArray(data)) {
+    throw new TypeError('data must be an array');
+  }
+  if (period <= 0) {
+    throw new Error('period must be a positive number');
+  }
+
+  const result = [];
+  let sum = 0;
+  for (let i = 0; i < data.length; i++) {
+    const price = Number(data[i][priceKey]);
+    if (isNaN(price)) {
+      result.push(undefined);
+      continue;
+    }
+    sum += price;
+    if (i >= period) {
+      const removePrice = Number(data[i - period][priceKey]);
+      if (!isNaN(removePrice)) {
+        sum -= removePrice;
+      }
+    }
+    if (i >= period - 1) {
+      result.push(sum / period);
+    } else {
+      result.push(undefined);
+    }
+  }
+  return result;
+}
+
+module.exports = calculateMA;


### PR DESCRIPTION
## Summary
- add `calculateMA` to compute moving averages of price data
- document usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684a9f8aab948322822a8f982e08052e