### PR TITLE
Implement averageVolumeLast50 in main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,1 +1,21 @@
-//该文件用于打印最后结果用的
+// 该文件用于打印最后结果用的
+const fs = require('fs');
+
+function averageVolumeLast50(records) {
+  if (!Array.isArray(records) || records.length === 0) {
+    throw new Error('records must be a non-empty array');
+  }
+  const last50 = records.slice(-50);
+  const total = last50.reduce((sum, entry) => sum + Number(entry.volume || 0), 0);
+  return total / last50.length;
+}
+
+// Example invocation using the provided AAPL.json dataset
+if (require.main === module) {
+  const data = JSON.parse(fs.readFileSync('AAPL.json', 'utf8')).data;
+  const avg = averageVolumeLast50(data);
+  console.log('Average volume (last 50 entries):', avg);
+}
+
+module.exports = { averageVolumeLast50 };
+


### PR DESCRIPTION
## Summary
- implement `averageVolumeLast50` helper
- show example usage against AAPL dataset

## Testing
- `node main.js | head -n 5`

------
https://chatgpt.com/codex/tasks/task_b_684ad36832ac8322936fd4bc61a62b0e