### PR TITLE
Add average volume indicator

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 
 const movingAverage = require('./src/indicators/movingAverage');
+const averageVolume = require('./src/indicators/averageVolume');
 
 // 读取并解析 JSON 文件
 const json = JSON.parse(fs.readFileSync('AAPL.json', 'utf-8'));
@@ -15,7 +16,9 @@ console.log('First close:', firstClose);
 const ma5 = movingAverage(json.data, 5);
 const ma50 = movingAverage(json.data, 50);
 const ma150 = movingAverage(json.data, 150);
+const av5 = averageVolume(json.data, 5);
 
 console.log('MA5:', ma5);
 console.log('MA50:', ma50);
 console.log('MA150:', ma150);
+console.log('AV5:', av5);

--- a/src/indicators/averageVolume.js
+++ b/src/indicators/averageVolume.js
@@ -1,0 +1,13 @@
+function averageVolume(data, period) {
+  if (!Array.isArray(data) || data.length < period) {
+    return null;
+  }
+  let sum = 0;
+  for (let i = data.length - period; i < data.length; i++) {
+    sum += data[i].volume;
+  }
+  const avg = sum / period;
+  return parseFloat(avg.toFixed(2));
+}
+
+module.exports = averageVolume;


### PR DESCRIPTION
## Summary
- add `averageVolume` indicator
- log average volume in `main.js`

## Testing
- `node main.js | head -n 6`

------
https://chatgpt.com/codex/tasks/task_b_684b8594afc88322bbbf29f66ce0c1f0