### PR TITLE
Add highest price indicator

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 
 const movingAverage = require('./src/indicators/movingAverage');
 const averageVolume = require('./src/indicators/averageVolume');
+const highestPrice52Weeks = require('./src/indicators/highestPrice52Weeks');
 
 // 读取并解析 JSON 文件
 const json = JSON.parse(fs.readFileSync('AAPL.json', 'utf-8'));
@@ -17,8 +18,10 @@ const ma5 = movingAverage(json.data, 5);
 const ma50 = movingAverage(json.data, 50);
 const ma150 = movingAverage(json.data, 150);
 const av5 = averageVolume(json.data, 5);
+const high52 = highestPrice52Weeks(json.data);
 
 console.log('MA5:', ma5);
 console.log('MA50:', ma50);
 console.log('MA150:', ma150);
 console.log('AV5:', av5);
+console.log('52 Week High:', high52);

--- a/src/indicators/highestPrice52Weeks.js
+++ b/src/indicators/highestPrice52Weeks.js
@@ -1,0 +1,20 @@
+function highestPrice52Weeks(data) {
+  if (!Array.isArray(data) || data.length === 0) {
+    return null;
+  }
+  const days = 52 * 5; // Approximate number of trading days in 52 weeks
+  const startIndex = Math.max(data.length - days, 0);
+  let maxHigh = -Infinity;
+  for (let i = startIndex; i < data.length; i++) {
+    const high = data[i].high;
+    if (typeof high === 'number' && high > maxHigh) {
+      maxHigh = high;
+    }
+  }
+  if (maxHigh === -Infinity) {
+    return null;
+  }
+  return parseFloat(maxHigh.toFixed(2));
+}
+
+module.exports = highestPrice52Weeks;


### PR DESCRIPTION
## Summary
- implement `highestPrice52Weeks` indicator
- log 52 week high in `main.js`

## Testing
- `node main.js`

------
https://chatgpt.com/codex/tasks/task_b_684b8b85d63c8322bbd1d2030be08b85