### PR TITLE
Implement stage one filter

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  stageOne: {
+    minPrice: 12,
+    minAvgVolume: 250000,
+    avgVolumePeriod: 50,
+    maShortPeriod: 50,
+    maMidPeriod: 150,
+    maLongPeriod: 200,
+    priceHighRatio: 0.75
+  }
+};

--- a/main.js
+++ b/main.js
@@ -1,27 +1,9 @@
-//该文件用于打印最后结果用的
-// main.js
 const fs = require('fs');
+const config = require('./config');
 
-const movingAverage = require('./src/indicators/movingAverage');
-const averageVolume = require('./src/indicators/averageVolume');
-const highestPrice52Weeks = require('./src/indicators/highestPrice52Weeks');
+const stageOneFilter = require('./src/stages/stageOneFilter');
 
-// 读取并解析 JSON 文件
 const json = JSON.parse(fs.readFileSync('AAPL.json', 'utf-8'));
 
-// 访问第一个记录的 close 值
-const firstClose = json.data[0].close;
-
-console.log('First close:', firstClose);
-
-const ma5 = movingAverage(json.data, 5);
-const ma50 = movingAverage(json.data, 50);
-const ma150 = movingAverage(json.data, 150);
-const av5 = averageVolume(json.data, 5);
-const high52 = highestPrice52Weeks(json.data);
-
-console.log('MA5:', ma5);
-console.log('MA50:', ma50);
-console.log('MA150:', ma150);
-console.log('AV5:', av5);
-console.log('52 Week High:', high52);
+const passed = stageOneFilter(json.data, config.stageOne);
+console.log('Stage One Passed:', passed);

--- a/src/stages/stageOneFilter.js
+++ b/src/stages/stageOneFilter.js
@@ -1,0 +1,39 @@
+const movingAverage = require('../indicators/movingAverage');
+const averageVolume = require('../indicators/averageVolume');
+const highestPrice52Weeks = require('../indicators/highestPrice52Weeks');
+
+function stageOneFilter(data, config) {
+  if (!Array.isArray(data) || data.length === 0) {
+    return false;
+  }
+
+  const latest = data[data.length - 1];
+  const price = latest.close;
+
+  const ma50 = movingAverage(data, config.maShortPeriod);
+  const ma150 = movingAverage(data, config.maMidPeriod);
+  const ma200 = movingAverage(data, config.maLongPeriod);
+  const avgVol = averageVolume(data, config.avgVolumePeriod);
+  const high52 = highestPrice52Weeks(data);
+
+  if (price <= config.minPrice) {
+    return false;
+  }
+
+  if (avgVol <= config.minAvgVolume) {
+    return false;
+  }
+
+  if (!(price > ma50 && ma50 > ma150 && ma150 > ma200)) {
+    return false;
+  }
+
+  const lowerBound = high52 * config.priceHighRatio;
+  if (!(price >= lowerBound && price <= high52)) {
+    return false;
+  }
+
+  return true;
+}
+
+module.exports = stageOneFilter;


### PR DESCRIPTION
## Summary
- add configurable params for scanning
- implement stage one filter that checks price, volume, moving averages and 52-week high
- simplify `main.js` to run the first stage filter on sample data

## Testing
- `node main.js`

------
https://chatgpt.com/codex/tasks/task_b_684b8fe4bc6c8322b8ad38eacf655aef