### PR TITLE
Add API fetch workflow

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,6 @@
 module.exports = {
+  period: 1440,
+  symbolsFile: 'symbols.txt',
   stageOne: {
     minPrice: 12,
     minAvgVolume: 250000,
@@ -6,6 +8,6 @@ module.exports = {
     maShortPeriod: 50,
     maMidPeriod: 150,
     maLongPeriod: 200,
-    priceHighRatio: 0.75
-  }
+    priceHighRatio: 0.75,
+  },
 };

--- a/main.js
+++ b/main.js
@@ -1,20 +1,54 @@
-const fs = require('fs');
+const fs = require('fs/promises');
 const config = require('./config');
 
+const { getMarketHistoricalData } = require('./src/api/fmpService');
 const stageOneFilter = require('./src/stages/stageOneFilter');
 const stageTwoVCP = require('./src/stages/stageTwoVCP');
 const stageThreeBreakout = require('./src/stages/stageThreeBreakout');
+const { saveResults } = require('./src/utils/fileHelper');
 
-const json = JSON.parse(fs.readFileSync('AAPL.json', 'utf-8'));
-
-const passed = stageOneFilter(json.data, config.stageOne);
-console.log('Stage One Passed:', passed);
-if (passed) {
-  const vcp = stageTwoVCP(json.data);
-  console.log('Stage Two Passed:', vcp);
-  if (vcp) {
-    const todayData = json.data[json.data.length - 1];
-    const breakout = stageThreeBreakout('AAPL', todayData, json.data);
-    console.log('Stage Three Result:', breakout);
-  }
+async function loadSymbols(file) {
+  const text = await fs.readFile(file, 'utf-8');
+  return text
+    .split(/\r?\n/)
+    .map(s => s.trim())
+    .filter(Boolean);
 }
+
+async function processSymbol(symbol) {
+  const json = await getMarketHistoricalData(config.period, symbol);
+  const data = json.data;
+  if (!data) return null;
+
+  if (!stageOneFilter(data, config.stageOne)) return null;
+  if (!stageTwoVCP(data)) return null;
+
+  const todayData = data[data.length - 1];
+  const breakout = stageThreeBreakout(symbol, todayData, data);
+  if (!breakout.breakout) return null;
+
+  return {
+    symbol,
+    price: todayData.close ?? todayData.price,
+    stopLoss: breakout.stopLoss,
+  };
+}
+
+async function main() {
+  const symbols = await loadSymbols(config.symbolsFile);
+  const results = [];
+  for (const sym of symbols) {
+    try {
+      const res = await processSymbol(sym);
+      if (res) results.push(res);
+    } catch (err) {
+      console.error(`Failed to process ${sym}:`, err.message);
+    }
+  }
+
+  const dateStr = new Date().toISOString().slice(0, 10);
+  await saveResults(dateStr, results);
+  console.log(`Completed. ${results.length} symbols passed all stages.`);
+}
+
+main();

--- a/src/api/fmpService.js
+++ b/src/api/fmpService.js
@@ -1,0 +1,12 @@
+async function getMarketHistoricalData(period, symbol) {
+  const response = await fetch(`https://backend.ymyc.ai/api/market-historical-data/${period}/${symbol}`);
+  if (!response.ok) {
+    throw new Error('Failed to get stock price');
+  }
+  const jsonData = await response.json();
+  return jsonData;
+}
+
+module.exports = {
+  getMarketHistoricalData,
+};

--- a/src/utils/fileHelper.js
+++ b/src/utils/fileHelper.js
@@ -1,0 +1,12 @@
+const fs = require('fs/promises');
+const path = require('path');
+
+async function saveResults(dateStr, results) {
+  const dir = path.resolve(__dirname, '../../results');
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, `${dateStr}_signals.json`);
+  await fs.writeFile(filePath, JSON.stringify(results, null, 2), 'utf-8');
+  return filePath;
+}
+
+module.exports = { saveResults };

--- a/symbols.txt
+++ b/symbols.txt
@@ -1,0 +1,3 @@
+AAPL
+MSFT
+GOOGL


### PR DESCRIPTION
## Summary
- load symbol list from `symbols.txt`
- add `fmpService` module for requesting historical data
- add file helper to save daily results under `results/`
- update `main.js` to iterate over symbols and save filtered breakout results
- configure fetch period and symbol file path in `config.js`

## Testing
- `node main.js` *(fails: `fetch failed`)*

------
https://chatgpt.com/codex/tasks/task_b_684b9d40e45483229977d58125b8aaab